### PR TITLE
nix: don't wrap helium as a Qt app

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -36,10 +36,9 @@
   pipewire,
   libpulseaudio,
   perSystem ?
-    if lib.trivial.pathExists ./versions.json
-    then lib.trivial.importJSON ./versions.json
-    else {},
-}: let
+    if lib.trivial.pathExists ./versions.json then lib.trivial.importJSON ./versions.json else { },
+}:
+let
   inherit (stdenv.hostPlatform) system isDarwin isLinux;
   inherit (lib.lists) optionals;
   inherit (lib.attrsets) getAttr attrNames;
@@ -47,123 +46,111 @@
 
   currentSystem = getAttr system perSystem;
 in
-  stdenv.mkDerivation {
-    pname = "helium";
-    inherit (currentSystem) version;
+stdenv.mkDerivation {
+  pname = "helium";
+  inherit (currentSystem) version;
 
-    src = fetchurl {inherit (currentSystem) url hash;};
+  src = fetchurl { inherit (currentSystem) url hash; };
 
-    nativeBuildInputs =
-      if isDarwin
-      then [makeBinaryWrapper]
-      else if isLinux
-      then [
+  nativeBuildInputs =
+    if isDarwin then
+      [ makeBinaryWrapper ]
+    else if isLinux then
+      [
         makeWrapper
         autoPatchelfHook
       ]
-      else [];
+    else
+      [ ];
 
-    buildInputs = optionals isLinux [
-      glib
-      gdk-pixbuf
-      gtk3
-      nspr
-      nss
-      dbus
-      atk
-      at-spi2-atk
-      cups
-      expat
-      libxcb
-      libxkbcommon
-      at-spi2-core
-      libx11
-      libxcomposite
-      libxdamage
-      libxext
-      libxfixes
-      libxrandr
-      mesa
-      cairo
-      pango
-      systemd
-      alsa-lib
-      libdrm
-      qt6.qtbase
-    ];
+  buildInputs = optionals isLinux [
+    glib
+    gdk-pixbuf
+    gtk3
+    nspr
+    nss
+    dbus
+    atk
+    at-spi2-atk
+    cups
+    expat
+    libxcb
+    libxkbcommon
+    at-spi2-core
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    mesa
+    cairo
+    pango
+    systemd
+    alsa-lib
+    libdrm
+    qt6.qtbase
+  ];
 
-    dontWrapQtApps = true;
+  dontWrapQtApps = true;
 
-    # Ignore Qt5 shim, qt5webengine is unmaintained & we're using Qt6
-    autoPatchelfIgnoreMissingDeps = optionals isLinux [
-      "libQt5Core.so.5"
-      "libQt5Gui.so.5"
-      "libQt5Widgets.so.5"
-    ];
+  # Ignore Qt5 shim, qt5webengine is unmaintained & we're using Qt6
+  autoPatchelfIgnoreMissingDeps = optionals isLinux [
+    "libQt5Core.so.5"
+    "libQt5Gui.so.5"
+    "libQt5Widgets.so.5"
+  ];
 
-    unpackCmd =
-      optionalString isDarwin
-      /*
-      sh
-      */
-      ''
-        mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-        trap "/usr/bin/hdiutil detach $mnt -force; rm -rf $mnt" EXIT
-        /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint $mnt $curSrc
-        cp --archive $mnt/Helium.app $PWD/
-      '';
+  unpackCmd = optionalString isDarwin /* sh */ ''
+    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+    trap "/usr/bin/hdiutil detach $mnt -force; rm -rf $mnt" EXIT
+    /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint $mnt $curSrc
+    cp --archive $mnt/Helium.app $PWD/
+  '';
 
-    sourceRoot = optionalString isDarwin ".";
+  sourceRoot = optionalString isDarwin ".";
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      ${optionalString isDarwin
-        /*
-        sh
-        */
-        ''
-          mkdir --parents $out/Applications
-          cp --archive Helium.app $out/Applications/Helium.app
+    ${optionalString isDarwin /* sh */ ''
+      mkdir --parents $out/Applications
+      cp --archive Helium.app $out/Applications/Helium.app
 
-          mkdir --parents $out/bin
-          makeBinaryWrapper $out/Applications/Helium.app/Contents/MacOS/Helium $out/bin/helium
-        ''}
+      mkdir --parents $out/bin
+      makeBinaryWrapper $out/Applications/Helium.app/Contents/MacOS/Helium $out/bin/helium
+    ''}
 
-      ${optionalString isLinux
-        /*
-        sh
-        */
-        ''
-          mkdir --parents $out/opt/helium
-          cp --recursive ./* $out/opt/helium/
+    ${optionalString isLinux /* sh */ ''
+      mkdir --parents $out/opt/helium
+      cp --recursive ./* $out/opt/helium/
 
-          mkdir --parents $out/bin
-          makeWrapper $out/opt/helium/helium-wrapper $out/bin/helium \
-            --prefix LD_LIBRARY_PATH : "${
-            makeLibraryPath [
-              libGL
-              libva
-              pipewire
-              libpulseaudio
-            ]
-          }"
+      mkdir --parents $out/bin
+      makeWrapper $out/opt/helium/helium-wrapper $out/bin/helium \
+        --prefix LD_LIBRARY_PATH : "${
+          makeLibraryPath [
+            libGL
+            libva
+            pipewire
+            libpulseaudio
+          ]
+        }"
 
-          mkdir --parents $out/share/applications
-          cp $out/opt/helium/helium.desktop $out/share/applications/
+      mkdir --parents $out/share/applications
+      cp $out/opt/helium/helium.desktop $out/share/applications/
 
-          mkdir --parents $out/share/pixmaps
-          cp $out/opt/helium/product_logo_256.png $out/share/pixmaps/helium.png
-        ''}
+      mkdir --parents $out/share/pixmaps
+      cp $out/opt/helium/product_logo_256.png $out/share/pixmaps/helium.png
+    ''}
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    meta = {
-      platforms = attrNames perSystem;
-      description = "A private, fast, and honest web browser";
-      homepage = "https://github.com/imputnet/helium";
-      license = lib.licenses.gpl3Only;
-      mainProgram = "helium";
-    };
-  }
+  meta = {
+    platforms = attrNames perSystem;
+    description = "A private, fast, and honest web browser";
+    homepage = "https://github.com/imputnet/helium";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "helium";
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -36,9 +36,10 @@
   pipewire,
   libpulseaudio,
   perSystem ?
-    if lib.trivial.pathExists ./versions.json then lib.trivial.importJSON ./versions.json else { },
-}:
-let
+    if lib.trivial.pathExists ./versions.json
+    then lib.trivial.importJSON ./versions.json
+    else {},
+}: let
   inherit (stdenv.hostPlatform) system isDarwin isLinux;
   inherit (lib.lists) optionals;
   inherit (lib.attrsets) getAttr attrNames;
@@ -46,110 +47,123 @@ let
 
   currentSystem = getAttr system perSystem;
 in
-stdenv.mkDerivation {
-  pname = "helium";
-  inherit (currentSystem) version;
+  stdenv.mkDerivation {
+    pname = "helium";
+    inherit (currentSystem) version;
 
-  src = fetchurl { inherit (currentSystem) url hash; };
+    src = fetchurl {inherit (currentSystem) url hash;};
 
-  nativeBuildInputs =
-    if isDarwin then
-      [ makeBinaryWrapper ]
-    else if isLinux then
-      [
+    nativeBuildInputs =
+      if isDarwin
+      then [makeBinaryWrapper]
+      else if isLinux
+      then [
         makeWrapper
         autoPatchelfHook
-        qt6.wrapQtAppsHook
       ]
-    else
-      [ ];
+      else [];
 
-  buildInputs = optionals isLinux [
-    glib
-    gdk-pixbuf
-    gtk3
-    nspr
-    nss
-    dbus
-    atk
-    at-spi2-atk
-    cups
-    expat
-    libxcb
-    libxkbcommon
-    at-spi2-core
-    libx11
-    libxcomposite
-    libxdamage
-    libxext
-    libxfixes
-    libxrandr
-    mesa
-    cairo
-    pango
-    systemd
-    alsa-lib
-    libdrm
-    qt6.qtbase
-  ];
+    buildInputs = optionals isLinux [
+      glib
+      gdk-pixbuf
+      gtk3
+      nspr
+      nss
+      dbus
+      atk
+      at-spi2-atk
+      cups
+      expat
+      libxcb
+      libxkbcommon
+      at-spi2-core
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      mesa
+      cairo
+      pango
+      systemd
+      alsa-lib
+      libdrm
+      qt6.qtbase
+    ];
 
-  # Ignore Qt5 shim, qt5webengine is unmaintained & we're using Qt6
-  autoPatchelfIgnoreMissingDeps = optionals isLinux [
-    "libQt5Core.so.5"
-    "libQt5Gui.so.5"
-    "libQt5Widgets.so.5"
-  ];
+    dontWrapQtApps = true;
 
-  unpackCmd = optionalString isDarwin /* sh */ ''
-    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
-    trap "/usr/bin/hdiutil detach $mnt -force; rm -rf $mnt" EXIT
-    /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint $mnt $curSrc
-    cp --archive $mnt/Helium.app $PWD/
-  '';
+    # Ignore Qt5 shim, qt5webengine is unmaintained & we're using Qt6
+    autoPatchelfIgnoreMissingDeps = optionals isLinux [
+      "libQt5Core.so.5"
+      "libQt5Gui.so.5"
+      "libQt5Widgets.so.5"
+    ];
 
-  sourceRoot = optionalString isDarwin ".";
+    unpackCmd =
+      optionalString isDarwin
+      /*
+      sh
+      */
+      ''
+        mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+        trap "/usr/bin/hdiutil detach $mnt -force; rm -rf $mnt" EXIT
+        /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint $mnt $curSrc
+        cp --archive $mnt/Helium.app $PWD/
+      '';
 
-  installPhase = ''
-    runHook preInstall
+    sourceRoot = optionalString isDarwin ".";
 
-    ${optionalString isDarwin /* sh */ ''
-      mkdir --parents $out/Applications
-      cp --archive Helium.app $out/Applications/Helium.app
+    installPhase = ''
+      runHook preInstall
 
-      mkdir --parents $out/bin
-      makeBinaryWrapper $out/Applications/Helium.app/Contents/MacOS/Helium $out/bin/helium
-    ''}
+      ${optionalString isDarwin
+        /*
+        sh
+        */
+        ''
+          mkdir --parents $out/Applications
+          cp --archive Helium.app $out/Applications/Helium.app
 
-    ${optionalString isLinux /* sh */ ''
-      mkdir --parents $out/opt/helium
-      cp --recursive ./* $out/opt/helium/
+          mkdir --parents $out/bin
+          makeBinaryWrapper $out/Applications/Helium.app/Contents/MacOS/Helium $out/bin/helium
+        ''}
 
-      mkdir --parents $out/bin
-      makeWrapper $out/opt/helium/helium-wrapper $out/bin/helium \
-        --prefix LD_LIBRARY_PATH : "${
-          makeLibraryPath [
-            libGL
-            libva
-            pipewire
-            libpulseaudio
-          ]
-        }"
+      ${optionalString isLinux
+        /*
+        sh
+        */
+        ''
+          mkdir --parents $out/opt/helium
+          cp --recursive ./* $out/opt/helium/
 
-      mkdir --parents $out/share/applications
-      cp $out/opt/helium/helium.desktop $out/share/applications/
+          mkdir --parents $out/bin
+          makeWrapper $out/opt/helium/helium-wrapper $out/bin/helium \
+            --prefix LD_LIBRARY_PATH : "${
+            makeLibraryPath [
+              libGL
+              libva
+              pipewire
+              libpulseaudio
+            ]
+          }"
 
-      mkdir --parents $out/share/pixmaps
-      cp $out/opt/helium/product_logo_256.png $out/share/pixmaps/helium.png
-    ''}
+          mkdir --parents $out/share/applications
+          cp $out/opt/helium/helium.desktop $out/share/applications/
 
-    runHook postInstall
-  '';
+          mkdir --parents $out/share/pixmaps
+          cp $out/opt/helium/product_logo_256.png $out/share/pixmaps/helium.png
+        ''}
 
-  meta = {
-    platforms = attrNames perSystem;
-    description = "A private, fast, and honest web browser";
-    homepage = "https://github.com/imputnet/helium";
-    license = lib.licenses.gpl3Only;
-    mainProgram = "helium";
-  };
-}
+      runHook postInstall
+    '';
+
+    meta = {
+      platforms = attrNames perSystem;
+      description = "A private, fast, and honest web browser";
+      homepage = "https://github.com/imputnet/helium";
+      license = lib.licenses.gpl3Only;
+      mainProgram = "helium";
+    };
+  }


### PR DESCRIPTION
I accidentally closed the previous pull request by syncing the fork, apologies for that. Here's the original description:

Currently the flake wraps Helium as a Qt app, so Helium can only follow Qt theming. By not wrapping it as a Qt app, Helium can follow both GTK and Qt theming. The browser still works as expected.