### PR TITLE
nix: gate Widevine behind helium-widevine variant

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
         ;
       inherit (lib.lists) foldl';
       inherit (lib.meta) getExe;
+      inherit (lib.strings) getName;
       inherit (lib.systems) flakeExposed;
       inherit (lib.trivial) importJSON pathExists;
 
@@ -21,7 +22,16 @@
 
       forAllSystems = f: genAttrs flakeExposed (system: f (import nixpkgs { inherit system; }));
       forSupportedSystems =
-        f: genAttrs (attrNames perSystem) (system: f (import nixpkgs { inherit system; }));
+        f:
+        genAttrs (attrNames perSystem) (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              config.allowUnfreePredicate = pkg: getName pkg == "widevine-cdm";
+            }
+          )
+        );
     in
     {
       checks = forSupportedSystems (pkgs: {
@@ -33,6 +43,10 @@
       packages = foldl' recursiveUpdate { } [
         (forSupportedSystems (pkgs: {
           helium = pkgs.callPackage ./package.nix { inherit perSystem; };
+          helium-widevine = pkgs.callPackage ./package.nix {
+            inherit perSystem;
+            withWidevine = true;
+          };
           default = self.packages.${pkgs.stdenv.hostPlatform.system}.helium;
         }))
 

--- a/package.nix
+++ b/package.nix
@@ -36,7 +36,7 @@
   pipewire,
   libpulseaudio,
   widevine-cdm,
-  withWidevine ? true,
+  withWidevine ? false,
   perSystem ?
     if lib.trivial.pathExists ./versions.json then lib.trivial.importJSON ./versions.json else { },
 }:


### PR DESCRIPTION
- Followup to #39

The reason being that widevine is unfree.